### PR TITLE
chore(renovate): auto-merge non-major helm & CI dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,5 +21,11 @@
       groupName: 'GitHub Actions',
       groupSlug: 'github-actions',
     },
+    {
+      description: 'Auto-merge non-major dependency updates already flagged for auto-merge (Helm charts + CI workflows). Major bumps stay manual.',
+      matchFileNames: ['charts/**', '.github/workflows/**'],
+      matchUpdateTypes: ['minor', 'patch', 'pin', 'digest'],
+      automerge: true,
+    },
   ],
 }


### PR DESCRIPTION
Signed-off-by: Sebastian Gaiser <sebastiangaiser@users.noreply.github.com>
